### PR TITLE
Structure into class library & add metadata

### DIFF
--- a/ketchupbot-framework/API/ApiManager.cs
+++ b/ketchupbot-framework/API/ApiManager.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
-using ketchupbot_updater.Types;
+using ketchupbot_framework.Types;
 using Newtonsoft.Json;
 
-namespace ketchupbot_updater.API;
+namespace ketchupbot_framework.API;
 
 /// <summary>
 /// API Manager for interacting with the Galaxy Info API. Responsible for fetching, processing, and returning properly formatted data from the Galaxy Info API.

--- a/ketchupbot-framework/API/MwClient.cs
+++ b/ketchupbot-framework/API/MwClient.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Web;
 using Newtonsoft.Json;
 
-namespace ketchupbot_updater.API;
+namespace ketchupbot_framework.API;
 
 public class MwClient
 {
@@ -122,10 +122,10 @@ public class MwClient
         return revision?.slots?.main?.content;
     }
 
-    public async Task EditArticle(string title, string newContent, string summary)
+    public async Task EditArticle(string title, string newContent, string summary, bool? dryRun = false)
     {
         // If dry run is enabled, don't actually make the edit. Mock success instead.
-        if (Program.DryRun) return;
+        if (dryRun == true) return;
 
         if (await IsLoggedIn() == false)
             throw new InvalidOperationException("Not logged in");

--- a/ketchupbot-framework/GlobalConfiguration.cs
+++ b/ketchupbot-framework/GlobalConfiguration.cs
@@ -1,4 +1,4 @@
-namespace ketchupbot_updater;
+namespace ketchupbot_framework;
 
 public static class GlobalConfiguration
 {

--- a/ketchupbot-framework/ShipUpdater.cs
+++ b/ketchupbot-framework/ShipUpdater.cs
@@ -10,7 +10,7 @@ namespace ketchupbot_framework;
 /// </summary>
 /// <param name="bot">The <see cref="MwClient"/> instance to use for interacting with the wiki</param>
 /// <param name="apiManager">The <see cref="ketchupbot_framework.API.ApiManager"/> instance to use for making API requests</param>
-public partial class ShipUpdater(MwClient bot, ApiManager apiManager)
+public partial class ShipUpdater(MwClient bot, ApiManager apiManager, bool dryRun = false)
 {
     private static string GetShipName(string data) => GlobalConfiguration.ShipNameMap.GetValueOrDefault(data, data);
 
@@ -189,7 +189,7 @@ public partial class ShipUpdater(MwClient bot, ApiManager apiManager)
 #endif
 
         // TODO: Make the edit summary more descriptive. Add in added, changed, and removed parameters.
-        await bot.EditArticle(ship, newWikitext, "Automated ship data update");
+        await bot.EditArticle(ship, newWikitext, "Automated ship data update", dryRun);
 
 #if DEBUG
         articleEditStart.Stop();

--- a/ketchupbot-framework/ShipUpdater.cs
+++ b/ketchupbot-framework/ShipUpdater.cs
@@ -1,15 +1,15 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
-using ketchupbot_updater.API;
+using ketchupbot_framework.API;
 using Serilog;
 
-namespace ketchupbot_updater;
+namespace ketchupbot_framework;
 
 /// <summary>
 /// Ship updater class to facilitate updating ship pages. You should pass this class to other classes via dependency injection.
 /// </summary>
 /// <param name="bot">The <see cref="MwClient"/> instance to use for interacting with the wiki</param>
-/// <param name="apiManager">The <see cref="ApiManager"/> instance to use for making API requests</param>
+/// <param name="apiManager">The <see cref="ketchupbot_framework.API.ApiManager"/> instance to use for making API requests</param>
 public partial class ShipUpdater(MwClient bot, ApiManager apiManager)
 {
     private static string GetShipName(string data) => GlobalConfiguration.ShipNameMap.GetValueOrDefault(data, data);

--- a/ketchupbot-framework/TurretUpdater.cs
+++ b/ketchupbot-framework/TurretUpdater.cs
@@ -1,8 +1,8 @@
 using System.Text.RegularExpressions;
-using ketchupbot_updater.API;
-using ketchupbot_updater.Types;
+using ketchupbot_framework.API;
+using ketchupbot_framework.Types;
 
-namespace ketchupbot_updater;
+namespace ketchupbot_framework;
 
 public class TurretUpdater(MwClient mwClient, ApiManager apiManager)
 {

--- a/ketchupbot-framework/Types/TurretData.cs
+++ b/ketchupbot-framework/Types/TurretData.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
-namespace ketchupbot_updater.Types;
+namespace ketchupbot_framework.Types;
 
 [Newtonsoft.Json.JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TurretTypeEnum

--- a/ketchupbot-framework/WikiParser.cs
+++ b/ketchupbot-framework/WikiParser.cs
@@ -2,7 +2,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
-namespace ketchupbot_updater;
+namespace ketchupbot_framework;
 
 /// <summary>
 /// Class that contains methods for parsing and manipulating wikitext & ship infobox json's

--- a/ketchupbot-framework/ketchupbot-framework.csproj
+++ b/ketchupbot-framework/ketchupbot-framework.csproj
@@ -11,7 +11,7 @@
 This project is a framework/library that provides the essential tools for updating the Galaxypedia.</Description>
         <Copyright>CC BY 4.0</Copyright>
         <PackageProjectUrl>https://github.com/smallketchup82/ketchupbot-updater</PackageProjectUrl>
-        <PackageLicenseUrl>https://creativecommons.org/licenses/by/4.0/</PackageLicenseUrl>
+        <PackageLicenseUrl></PackageLicenseUrl>
         <RepositoryUrl>https://github.com/smallketchup82/ketchupbot-updater</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>

--- a/ketchupbot-framework/ketchupbot-framework.csproj
+++ b/ketchupbot-framework/ketchupbot-framework.csproj
@@ -17,6 +17,7 @@ This project is a framework/library that provides the essential tools for updati
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Serilog" Version="4.0.1" />
     </ItemGroup>

--- a/ketchupbot-framework/ketchupbot-framework.csproj
+++ b/ketchupbot-framework/ketchupbot-framework.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <RootNamespace>ketchupbot_framework</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <Version>4.0.0</Version>
+        <Description>KetchupBot-Updater: The premier Galaxypedia Updater
+
+This project is a framework/library that provides the essential tools for updating the Galaxypedia.</Description>
+        <Copyright>CC BY 4.0</Copyright>
+        <PackageProjectUrl>https://github.com/smallketchup82/ketchupbot-updater</PackageProjectUrl>
+        <PackageLicenseUrl>https://creativecommons.org/licenses/by/4.0/</PackageLicenseUrl>
+        <RepositoryUrl>https://github.com/smallketchup82/ketchupbot-updater</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="Serilog" Version="4.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/ketchupbot-updater-tests/ShipUpdater/UpdateAllShipsTests.cs
+++ b/ketchupbot-updater-tests/ShipUpdater/UpdateAllShipsTests.cs
@@ -1,5 +1,3 @@
-using ketchupbot_updater.API;
-using Moq;
 
 namespace ketchupbot_updater_tests.ShipUpdater;
 

--- a/ketchupbot-updater-tests/WikiParser/CheckIfInfoboxesChangedTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/CheckIfInfoboxesChangedTests.cs
@@ -8,7 +8,7 @@ public class CheckIfInfoboxesChangedTests
         var oldData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
         var newData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "differentValue" } };
 
-        bool result = ketchupbot_updater.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
+        bool result = ketchupbot_framework.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
 
         Assert.True(result);
     }
@@ -19,7 +19,7 @@ public class CheckIfInfoboxesChangedTests
         var oldData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
         var newData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
 
-        bool result = ketchupbot_updater.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
+        bool result = ketchupbot_framework.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
 
         Assert.False(result);
     }
@@ -30,7 +30,7 @@ public class CheckIfInfoboxesChangedTests
         var oldData = new Dictionary<string, string> { { "key1", "value1" } };
         var newData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
 
-        bool result = ketchupbot_updater.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
+        bool result = ketchupbot_framework.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
 
         Assert.True(result);
     }
@@ -41,7 +41,7 @@ public class CheckIfInfoboxesChangedTests
         var oldData = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
         var newData = new Dictionary<string, string> { { "key1", "value1" } };
 
-        bool result = ketchupbot_updater.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
+        bool result = ketchupbot_framework.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
 
         Assert.True(result);
     }
@@ -52,7 +52,7 @@ public class CheckIfInfoboxesChangedTests
         var oldData = new Dictionary<string, string>();
         var newData = new Dictionary<string, string>();
 
-        bool result = ketchupbot_updater.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
+        bool result = ketchupbot_framework.WikiParser.CheckIfInfoboxesChanged(oldData, newData);
 
         Assert.False(result);
     }

--- a/ketchupbot-updater-tests/WikiParser/ExtractInfoboxTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/ExtractInfoboxTests.cs
@@ -7,7 +7,7 @@ public class ExtractInfoboxTests
     {
         const string pageText = "{{Ship Infobox|name=Test Ship|type=Destroyer}}";
 
-        string result = ketchupbot_updater.WikiParser.ExtractInfobox(pageText);
+        string result = ketchupbot_framework.WikiParser.ExtractInfobox(pageText);
 
         Assert.Equal("{{Ship Infobox|name=Test Ship|type=Destroyer}}", result);
     }
@@ -17,7 +17,7 @@ public class ExtractInfoboxTests
     {
         const string pageText = "This page does not contain an infobox.";
 
-        Assert.Throws<InvalidOperationException>(() => ketchupbot_updater.WikiParser.ExtractInfobox(pageText));
+        Assert.Throws<InvalidOperationException>(() => ketchupbot_framework.WikiParser.ExtractInfobox(pageText));
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public class ExtractInfoboxTests
     {
         const string pageText = "{{Ship Infobox|name=First Ship|type=Destroyer}}{{Ship Infobox|name=Second Ship|type=Cruiser}}";
 
-        string result = ketchupbot_updater.WikiParser.ExtractInfobox(pageText);
+        string result = ketchupbot_framework.WikiParser.ExtractInfobox(pageText);
 
         Assert.Equal("{{Ship Infobox|name=First Ship|type=Destroyer}}", result);
     }
@@ -35,20 +35,19 @@ public class ExtractInfoboxTests
     {
         const string pageText = "{{Ship Infobox|name=Test Ship|type=Destroyer|nested={{NestedTemplate|param=value}}}}";
 
-        string result = ketchupbot_updater.WikiParser.ExtractInfobox(pageText);
+        string result = ketchupbot_framework.WikiParser.ExtractInfobox(pageText);
 
         Assert.Equal("{{Ship Infobox|name=Test Ship|type=Destroyer|nested={{NestedTemplate|param=value}}}}", result);
     }
 
-    [Fact]
-    public void ExtractInfobox_ReturnsInfobox_WhenInfoboxContainsSpecialCharacters()
-    {
-        // SplitTemplate doesn't handle special characters, so this test is invalid. But hopefully it will be fixed in the future, so I'll leave this test here.
-        return;
-        const string pageText = "{{Ship Infobox|name=Test Ship|type=Destroyer|description=This is a test ship with special characters: [ ] { } | }}";
-
-        string result = ketchupbot_updater.WikiParser.ExtractInfobox(pageText);
-
-        Assert.Equal("{{Ship Infobox|name=Test Ship|type=Destroyer|description=This is a test ship with special characters: [ ] { } | }}", result);
-    }
+    // SplitTemplate doesn't handle special characters, so this test is invalid. But hopefully it will be fixed in the future, so I'll leave this test here.
+    // [Fact]
+    // public void ExtractInfobox_ReturnsInfobox_WhenInfoboxContainsSpecialCharacters()
+    // {
+    //     const string pageText = "{{Ship Infobox|name=Test Ship|type=Destroyer|description=This is a test ship with special characters: [ ] { } | }}";
+    //
+    //     string result = ketchupbot_framework.WikiParser.ExtractInfobox(pageText);
+    //
+    //     Assert.Equal("{{Ship Infobox|name=Test Ship|type=Destroyer|description=This is a test ship with special characters: [ ] { } | }}", result);
+    // }
 }

--- a/ketchupbot-updater-tests/WikiParser/ExtractTurretTablesTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/ExtractTurretTablesTests.cs
@@ -9,7 +9,7 @@ public class ExtractTurretTablesTests
     {
         const string text = "{| class=\"wikitable sortable\" ... |}";
 
-        MatchCollection result = ketchupbot_updater.WikiParser.ExtractTurretTables(text);
+        MatchCollection result = ketchupbot_framework.WikiParser.ExtractTurretTables(text);
 
         Assert.NotNull(result);
         Assert.True(result.Count > 0);
@@ -20,7 +20,7 @@ public class ExtractTurretTablesTests
     {
         const string text = "No turret tables here";
 
-        Assert.Throws<InvalidOperationException>(() => ketchupbot_updater.WikiParser.ExtractTurretTables(text));
+        Assert.Throws<InvalidOperationException>(() => ketchupbot_framework.WikiParser.ExtractTurretTables(text));
     }
 
     [Fact]
@@ -28,6 +28,6 @@ public class ExtractTurretTablesTests
     {
         string text = string.Concat(Enumerable.Repeat("{| class=\"wikitable sortable\" ... |}", 7));
 
-        Assert.Throws<InvalidOperationException>(() => ketchupbot_updater.WikiParser.ExtractTurretTables(text));
+        Assert.Throws<InvalidOperationException>(() => ketchupbot_framework.WikiParser.ExtractTurretTables(text));
     }
 }

--- a/ketchupbot-updater-tests/WikiParser/MergeDataTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/MergeDataTests.cs
@@ -61,7 +61,7 @@ public class MergeDataTests
             ["description"] = "Merge test"
         };
 
-        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_updater.WikiParser.MergeData(newData, SampleDeityPage);
+        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_framework.WikiParser.MergeData(newData, SampleDeityPage);
 
         foreach (KeyValuePair<string, string> kvp in mergedData.Item1) Assert.Equal(kvp.Key == "description" ? "Merge test" : SampleDeityPage[kvp.Key], kvp.Value);
     }
@@ -69,7 +69,7 @@ public class MergeDataTests
     [Fact]
     public void MergeData_ChangesNothing()
     {
-        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_updater.WikiParser.MergeData(SampleApiResponse, SampleDeityPage);
+        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_framework.WikiParser.MergeData(SampleApiResponse, SampleDeityPage);
 
         Assert.Equal(SampleDeityPage, mergedData.Item1);
     }
@@ -82,7 +82,7 @@ public class MergeDataTests
             ["new_key"] = "new_value"
         };
 
-        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_updater.WikiParser.MergeData(newData, SampleDeityPage);
+        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_framework.WikiParser.MergeData(newData, SampleDeityPage);
 
         foreach (KeyValuePair<string, string> kvp in mergedData.Item1) Assert.Equal(kvp.Key == "new_key" ? "new_value" : SampleDeityPage[kvp.Key], kvp.Value);
     }
@@ -93,7 +93,7 @@ public class MergeDataTests
         Dictionary<string, string> newData = new(SampleApiResponse);
         newData.Remove("description");
 
-        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_updater.WikiParser.MergeData(newData, SampleDeityPage);
+        Tuple<Dictionary<string, string>, List<string>> mergedData = ketchupbot_framework.WikiParser.MergeData(newData, SampleDeityPage);
 
         foreach (KeyValuePair<string, string> kvp in mergedData.Item1) Assert.Equal(SampleDeityPage[kvp.Key], kvp.Value);
     }

--- a/ketchupbot-updater-tests/WikiParser/ObjectToWikitextTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/ObjectToWikitextTests.cs
@@ -11,7 +11,7 @@ public class ObjectToWikitextTests
             { "type", "Destroyer" }
         };
 
-        string result = ketchupbot_updater.WikiParser.ObjectToWikitext(data);
+        string result = ketchupbot_framework.WikiParser.ObjectToWikitext(data);
 
         Assert.Equal("{{Ship Infobox\n|name = Test Ship\n|type = Destroyer\n}}", result);
     }
@@ -21,7 +21,7 @@ public class ObjectToWikitextTests
     {
         var data = new Dictionary<string, string>();
 
-        string result = ketchupbot_updater.WikiParser.ObjectToWikitext(data);
+        string result = ketchupbot_framework.WikiParser.ObjectToWikitext(data);
 
         Assert.Equal("{{Ship Infobox\n}}", result);
     }
@@ -35,7 +35,7 @@ public class ObjectToWikitextTests
             { "type", "Destroyer" }
         };
 
-        string result = ketchupbot_updater.WikiParser.ObjectToWikitext(data);
+        string result = ketchupbot_framework.WikiParser.ObjectToWikitext(data);
 
         Assert.Equal("{{Ship Infobox\n|name = Test $$hip\n|type = Destroyer\n}}", result);
     }

--- a/ketchupbot-updater-tests/WikiParser/ParseInfoboxTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/ParseInfoboxTests.cs
@@ -7,7 +7,7 @@ public class ParseInfoboxTests
     public void ParseInfobox_ValidInfobox_ReturnsDictionary()
     {
         const string infobox = "{{Ship Infobox|name=Test Ship|type=Destroyer|image=<gallery>image1.jpg</gallery>}}";
-        Dictionary<string, string> result = ketchupbot_updater.WikiParser.ParseInfobox(infobox);
+        Dictionary<string, string> result = ketchupbot_framework.WikiParser.ParseInfobox(infobox);
         Assert.Equal(3, result.Count);
         Assert.Equal("Test Ship", result["name"]);
         Assert.Equal("Destroyer", result["type"]);
@@ -18,7 +18,7 @@ public class ParseInfoboxTests
     public void ParseInfobox_InfoboxWithoutImage_ReturnsDictionary()
     {
         const string infobox = "{{Ship Infobox|name=Test Ship|type=Destroyer}}";
-        Dictionary<string, string> result = ketchupbot_updater.WikiParser.ParseInfobox(infobox);
+        Dictionary<string, string> result = ketchupbot_framework.WikiParser.ParseInfobox(infobox);
         Assert.Equal(2, result.Count);
         Assert.Equal("Test Ship", result["name"]);
         Assert.Equal("Destroyer", result["type"]);
@@ -28,14 +28,14 @@ public class ParseInfoboxTests
     public void ParseInfobox_InfoboxWithMalformedGallery_ThrowsException()
     {
         const string infobox = "{{Ship Infobox|name=Test Ship|type=Destroyer|image=<gallery>image1.jpg}}";
-        Assert.Throws<InvalidOperationException>(() => ketchupbot_updater.WikiParser.ParseInfobox(infobox));
+        Assert.Throws<InvalidOperationException>(() => ketchupbot_framework.WikiParser.ParseInfobox(infobox));
     }
 
     [Fact]
     public void ParseInfobox_EmptyInfobox_ReturnsEmptyDictionary()
     {
         const string infobox = "{{Ship Infobox}}";
-        Dictionary<string, string> result = ketchupbot_updater.WikiParser.ParseInfobox(infobox);
+        Dictionary<string, string> result = ketchupbot_framework.WikiParser.ParseInfobox(infobox);
         Assert.Empty(result);
     }
 
@@ -43,7 +43,7 @@ public class ParseInfoboxTests
     public void ParseInfobox_InfoboxWithNoEqualsSign_ReturnsEmptyDictionary()
     {
         const string infobox = "{{Ship Infobox|name|type}}";
-        Dictionary<string, string> result = ketchupbot_updater.WikiParser.ParseInfobox(infobox);
+        Dictionary<string, string> result = ketchupbot_framework.WikiParser.ParseInfobox(infobox);
         Assert.Empty(result);
     }
 }

--- a/ketchupbot-updater-tests/WikiParser/ReplaceInfoboxTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/ReplaceInfoboxTests.cs
@@ -8,7 +8,7 @@ public class ReplaceInfoboxTests
         const string pageText = "Some text before {{Ship Infobox|param1=value1|param2=value2}} some text after";
         const string newInfobox = "{{Ship Infobox|param1=newValue1|param2=newValue2}}";
 
-        string result = ketchupbot_updater.WikiParser.ReplaceInfobox(pageText, newInfobox);
+        string result = ketchupbot_framework.WikiParser.ReplaceInfobox(pageText, newInfobox);
 
         Assert.Equal("Some text before {{Ship Infobox|param1=newValue1|param2=newValue2}} some text after", result);
     }
@@ -19,7 +19,7 @@ public class ReplaceInfoboxTests
         const string pageText = "Some text without infobox";
         const string newInfobox = "{{Ship Infobox|param1=newValue1|param2=newValue2}}";
 
-        string result = ketchupbot_updater.WikiParser.ReplaceInfobox(pageText, newInfobox);
+        string result = ketchupbot_framework.WikiParser.ReplaceInfobox(pageText, newInfobox);
 
         Assert.Equal(pageText, result);
     }
@@ -30,7 +30,7 @@ public class ReplaceInfoboxTests
         const string pageText = "Some text before {{Ship Infobox|param1=value1|param2=value2 some text after";
         const string newInfobox = "{{Ship Infobox|param1=newValue1|param2=newValue2}}";
 
-        string result = ketchupbot_updater.WikiParser.ReplaceInfobox(pageText, newInfobox);
+        string result = ketchupbot_framework.WikiParser.ReplaceInfobox(pageText, newInfobox);
 
         Assert.Equal(pageText, result);
     }

--- a/ketchupbot-updater-tests/WikiParser/SanitizeDataTests.cs
+++ b/ketchupbot-updater-tests/WikiParser/SanitizeDataTests.cs
@@ -1,4 +1,4 @@
-using ketchupbot_updater;
+using ketchupbot_framework;
 
 namespace ketchupbot_updater_tests.WikiParser;
 
@@ -12,7 +12,7 @@ public class SanitizeDataTests
         var data = new Dictionary<string, string> { { "title1", "Some Title" }, { "description", "Some Description" } };
         var oldData = new Dictionary<string, string>();
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         Assert.DoesNotContain("title1", result.Item1.Keys);
     }
@@ -23,7 +23,7 @@ public class SanitizeDataTests
         var data = new Dictionary<string, string> { { "title", "Some Title" } };
         var oldData = new Dictionary<string, string>();
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         Assert.Equal("The Some Title", result.Item1["title"]);
     }
@@ -34,7 +34,7 @@ public class SanitizeDataTests
         var data = new Dictionary<string, string> { { "description", "Line1\nLine2" } };
         var oldData = new Dictionary<string, string>();
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         Assert.Equal("Line1 Line2", result.Item1["description"]);
     }
@@ -45,7 +45,7 @@ public class SanitizeDataTests
         var data = new Dictionary<string, string> { { "someDouble", "1.0" } };
         var oldData = new Dictionary<string, string>();
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         Assert.Equal("1", result.Item1["someDouble"]);
     }
@@ -56,7 +56,7 @@ public class SanitizeDataTests
         var data = new Dictionary<string, string> { { "someDouble", "0.2" } };
         var oldData = new Dictionary<string, string>();
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         Assert.Equal("0.20", result.Item1["someDouble"]);
     }
@@ -67,7 +67,7 @@ public class SanitizeDataTests
         var data = new Dictionary<string, string> { { "someNumber", "1000" } };
         var oldData = new Dictionary<string, string>();
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         Assert.Equal("1,000", result.Item1["someNumber"]);
     }
@@ -78,7 +78,7 @@ public class SanitizeDataTests
         var data = new Dictionary<string, string> { { "someKey", "no" } };
         var oldData = new Dictionary<string, string> { { "someKey", "no" } };
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         Assert.DoesNotContain("someKey", result.Item1.Keys);
     }
@@ -91,7 +91,7 @@ public class SanitizeDataTests
 
         GlobalConfiguration.ParametersToDeleteIfValueIsYes.Add("someKey");
 
-        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_updater.WikiParser.SanitizeData(data, oldData);
+        Tuple<Dictionary<string, string>, List<string>> result = ketchupbot_framework.WikiParser.SanitizeData(data, oldData);
 
         GlobalConfiguration.ParametersToDeleteIfValueIsYes.Remove("someKey");
 

--- a/ketchupbot-updater-tests/ketchupbot-updater-tests.csproj
+++ b/ketchupbot-updater-tests/ketchupbot-updater-tests.csproj
@@ -25,12 +25,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\ketchupbot-updater\ketchupbot-updater.csproj" />
+      <Folder Include="ApiManager\" />
+      <Folder Include="MwClient\" />
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="ApiManager\" />
-      <Folder Include="MwClient\" />
+      <ProjectReference Include="..\ketchupbot-framework\ketchupbot-framework.csproj" />
     </ItemGroup>
 
 </Project>

--- a/ketchupbot-updater.sln
+++ b/ketchupbot-updater.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ketchupbot-updater", "ketch
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ketchupbot-updater-tests", "ketchupbot-updater-tests\ketchupbot-updater-tests.csproj", "{70DD68ED-11B5-4B76-9663-2CDE5ACC5E5E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ketchupbot-framework", "ketchupbot-framework\ketchupbot-framework.csproj", "{CEA415C6-6CA0-4117-9962-CFEB79371AD8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{70DD68ED-11B5-4B76-9663-2CDE5ACC5E5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70DD68ED-11B5-4B76-9663-2CDE5ACC5E5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70DD68ED-11B5-4B76-9663-2CDE5ACC5E5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CEA415C6-6CA0-4117-9962-CFEB79371AD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CEA415C6-6CA0-4117-9962-CFEB79371AD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CEA415C6-6CA0-4117-9962-CFEB79371AD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CEA415C6-6CA0-4117-9962-CFEB79371AD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/ketchupbot-updater/Jobs/MassUpdateJob.cs
+++ b/ketchupbot-updater/Jobs/MassUpdateJob.cs
@@ -1,3 +1,4 @@
+using ketchupbot_framework;
 using Quartz;
 
 namespace ketchupbot_updater.Jobs;

--- a/ketchupbot-updater/Jobs/TurretUpdateJob.cs
+++ b/ketchupbot-updater/Jobs/TurretUpdateJob.cs
@@ -1,3 +1,4 @@
+using ketchupbot_framework;
 using Quartz;
 
 namespace ketchupbot_updater.Jobs;

--- a/ketchupbot-updater/Program.cs
+++ b/ketchupbot-updater/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.CommandLine;
 using System.Reflection;
-using ketchupbot_updater.API;
+using ketchupbot_framework;
+using ketchupbot_framework.API;
 using ketchupbot_updater.Jobs;
 using Microsoft.Extensions.Configuration;
 using Quartz;

--- a/ketchupbot-updater/ketchupbot-updater.csproj
+++ b/ketchupbot-updater/ketchupbot-updater.csproj
@@ -12,6 +12,14 @@
         <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <FileVersion>4.0.0.0</FileVersion>
         <Version>4.0.0</Version>
+        <Description>KetchupBot-Updater: The Premier Galaxypedia Updater
+
+This project is a standalone application that builds upon ketchupbot-framework to provide an intuitive interface to ketchupbot-updater</Description>
+        <Copyright>https://creativecommons.org/licenses/by/4.0/</Copyright>
+        <PackageProjectUrl>https://github.com/smallketchup82/ketchupbot-updater</PackageProjectUrl>
+        <PackageLicenseUrl>https://creativecommons.org/licenses/by/4.0/</PackageLicenseUrl>
+        <RepositoryUrl>https://github.com/smallketchup82/ketchupbot-updater</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -42,6 +50,10 @@
       <Content Include="..\.dockerignore">
         <Link>.dockerignore</Link>
       </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ketchupbot-framework\ketchupbot-framework.csproj" />
     </ItemGroup>
 
 </Project>

--- a/ketchupbot-updater/ketchupbot-updater.csproj
+++ b/ketchupbot-updater/ketchupbot-updater.csproj
@@ -17,7 +17,7 @@
 This project is a standalone application that builds upon ketchupbot-framework to provide an intuitive interface to ketchupbot-updater</Description>
         <Copyright>https://creativecommons.org/licenses/by/4.0/</Copyright>
         <PackageProjectUrl>https://github.com/smallketchup82/ketchupbot-updater</PackageProjectUrl>
-        <PackageLicenseUrl>https://creativecommons.org/licenses/by/4.0/</PackageLicenseUrl>
+        <PackageLicenseUrl></PackageLicenseUrl>
         <RepositoryUrl>https://github.com/smallketchup82/ketchupbot-updater</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>

--- a/ketchupbot-updater/ketchupbot-updater.csproj
+++ b/ketchupbot-updater/ketchupbot-updater.csproj
@@ -23,12 +23,9 @@ This project is a standalone application that builds upon ketchupbot-framework t
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Colorful.Console" Version="1.2.15" />
-      <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Quartz" Version="3.12.0" />
       <PackageReference Include="Serilog" Version="4.0.1" />
       <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />


### PR DESCRIPTION
Closes #102 

Allows ketchupbot to be extensible, meaning projects like ketchupbot-discord can access its methods.

Minor workaround was needed to bring back dryRun functionality. I mostly just DI'ed it.